### PR TITLE
Fixed non-functional documentation typos

### DIFF
--- a/AoA Indexer/README.md
+++ b/AoA Indexer/README.md
@@ -6,7 +6,7 @@
 
 ![CAD](assets/cad.png)
 
-Note: 3D printing warning lights' lables might not have good clear text. To have clear text layer, print [Warning Lights - Text](Warning%20Lights%20-%20Text.pdf) PDF file on a clear sheet, then cut them and place in warnig lights slots.
+Note: 3D printing warning lights' labels might not have good clear text. To have clear text layer, print [Warning Lights - Text](Warning%20Lights%20-%20Text.pdf) PDF file on a clear sheet, then cut them and place in warnig lights slots.
 
 ## License
 

--- a/AoA Indexer/README.md
+++ b/AoA Indexer/README.md
@@ -6,7 +6,7 @@
 
 ![CAD](assets/cad.png)
 
-Note: 3D printing warning lights' labels might not have good clear text. To have clear text layer, print [Warning Lights - Text](Warning%20Lights%20-%20Text.pdf) PDF file on a clear sheet, then cut them and place in warnig lights slots.
+Note: 3D printing warning lights' labels might not have good clear text. To have clear text layer, print [Warning Lights - Text](Warning%20Lights%20-%20Text.pdf) PDF file on a clear sheet, then cut them and place in warning lights slots.
 
 ## License
 

--- a/Radio Panel/README.md
+++ b/Radio Panel/README.md
@@ -7,7 +7,7 @@ AN/ARC-159(V) 1 UHF Control Panel for DCS F-14B Tomcat. Built with Arduino compa
 * 5V/16MHz Pro Micro Board w/ ATmega32U4
 * TM1637 6-Digit 7-Segment LED
 * Mini toggle switches:
-  * 4 (on)-off-(on) for freqency dials
+  * 4 (on)-off-(on) for frequency dials
   * 1 on-off for SQL
   * 1 (on)-off for READ
 * 2 potentiometers for VOL and BRT


### PR DESCRIPTION
This pull request addresses a series of minor typographical errors identified across the codebase.

### Summary of changes:
- `AoA Indexer/README.md`, line 9: `lables` → `labels`
- `AoA Indexer/README.md`, line 9: `warnig` → `warning`
- `Radio Panel/README.md`, line 10: `freqency` → `frequency`

These changes are cosmetic and do not impact functionality.